### PR TITLE
Add TWZRD Agent Intel: verifiable trust receipts for AI agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ Notable self-sovereign identity products and services that are in production.
 - [Paradym](https://paradym.id/) - SaaS platform for building your SSI solutions.
 - [Trinsic](https://trinsic.id/) - An end-to-end self sovereign identity platform by Trinsic.
 - [VC on Internet Identity](https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md) - A wallet-less and privacy preserving VC protocol built on top Internet Identity on ICP.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Verifiable trust receipts for Solana AI agents. Cryptographically signed attestations (structurally similar to W3C Verifiable Credentials) proving agent wallet identity and trust score; callable via MCP. Zero-install integration.
 - [Veramo](https://veramo.io/) - APIs for self-sovereign identity.
 - [walt.id](https://walt.id/identity-infrastructure) - Build end-to-end digital identity use cases or applications with ease.
 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — verifiable trust receipts for Solana AI agents.

Cryptographically signed `twzrd.receipt.v5` attestations proving an AI agent's Solana wallet identity and on-chain trust score. Structurally similar to W3C Verifiable Credentials, but purpose-built for the AI agent layer.

**Why it fits the Products & Services section**: TWZRD issues machine-readable, cryptographically verifiable attestations about agent identity — the same problem W3C VCs solve for humans, applied to autonomous AI agents with Solana wallet identities.

**MCP-native**: Zero-install integration via `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`.

**Tools**:
- `score_agent(wallet)` — free trust score lookup
- `preflight_check(wallet)` — free identity preflight
- `get_trust_receipt(wallet)` — paid (HTTP 402), returns signed receipt

Added alphabetically under **Notable self-sovereign identity products and services** (before Veramo).